### PR TITLE
Replicate llama2 support

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -35,3 +35,5 @@ TWILIO_AUTH_TOKEN=*****
 
 # Steamship related environment variables
 STEAMSHIP_API_KEY=****
+
+LLM_MODEL=openai

--- a/src/app/api/interact/route.ts
+++ b/src/app/api/interact/route.ts
@@ -9,6 +9,7 @@ import { PromptTemplate } from "langchain/prompts";
 import { generateEmojiPrompt, INTERACTION } from "@/app/utils/interaction";
 import { LLMChain } from "langchain/chains";
 import { eating, idle, superFull } from "@/components/tamagotchiFrames";
+import { getModel } from "@/app/utils/model"
 
 dotenv.config({ path: `.env.local` });
 
@@ -26,10 +27,7 @@ export async function POST(req: Request) {
   console.debug("interactionType", interactionType);
   let animation = idle;
 
-  const model = new OpenAI({
-    modelName: "gpt-3.5-turbo-16k",
-    openAIApiKey: process.env.OPENAI_API_KEY,
-  });
+  const model = getModel();
   model.verbose = true;
 
   switch (interactionType) {
@@ -47,7 +45,7 @@ export async function POST(req: Request) {
       Return in JSON what food you prefer to eat, and your rating of the food after eating it. Rate the food from 1-5, where 1 being you hate the food, and 5 being you loved it. 
       
       Example (for demonstration purpose):
-      {{food: sushi, rating: 1}}
+      {{"food": "sushi", "rating": 1}}
       `);
 
         const eatChain = new LLMChain({
@@ -59,8 +57,9 @@ export async function POST(req: Request) {
           .call({ stats: JSON.stringify(stats) })
           .catch(console.error);
         const { text } = result!;
-        const food = JSON.parse(text).food;
-        const rating = JSON.parse(text).rating;
+        const resultJson = JSON.parse(text);
+        const food = resultJson.food;
+        const rating = resultJson.rating;
         console.debug(food, rating);
 
         // generate animations

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,11 @@
 import Navbar from "@/components/Navbar";
-import Examples from "@/components/Examples";
 import Tamagotchi from "@/components/Tamagotchi";
 
 export default function Home() {
   return (
     <main className="flex min-h-screen flex-col items-center justify-between">
       {/* <Navbar /> */}
-      <Tamagotchi/>
+      <Tamagotchi />
     </main>
   );
 }

--- a/src/app/utils/config.ts
+++ b/src/app/utils/config.ts
@@ -1,5 +1,4 @@
 import fs from "fs";
-import { Config } from "twilio/lib/twiml/VoiceResponse";
 
 class ConfigManager {
   private static instance: ConfigManager;

--- a/src/app/utils/interaction.ts
+++ b/src/app/utils/interaction.ts
@@ -8,7 +8,7 @@ export enum INTERACTION {
   // TODO - add other types
 }
 
-export const generateEmojiPrompt = `Return one or more emojis and nothing else. Generate emoji(s) based on this food: {food}`;
+export const generateEmojiPrompt = `Return one or more unicode emojis and nothing else. Generate emoji(s) based on this food: {food}`;
 
 //TODO - turns out chatgpt is terrible at generating consistent animation frames. Explore more later?
 export const eatAnimationPrompt = `

--- a/src/app/utils/model.ts
+++ b/src/app/utils/model.ts
@@ -1,0 +1,35 @@
+
+import { OpenAI } from "langchain/llms/openai";
+import { Replicate } from "langchain/llms/replicate";
+
+enum LlmModel {
+    OpenAI = 'openai',
+    ReplicateLlama = 'replicate_llama',
+}
+export function getModel() {
+    const model = (process.env.LLM_MODEL || "").toLowerCase()
+    console.log("model", model)
+    if (model == LlmModel.ReplicateLlama) {
+        console.debug("Using Replicate Llama")
+        return new Replicate({
+            apiKey: process.env.REPLICATE_API_TOKEN,
+            model:
+                //newer versions have emojis broken 😔
+                "meta/llama13b-v2-chat:2d19859030ff705a87c746f7e96eea03aefb71f166725aee39692f1476566d48",
+            input: {
+                system_prompt: `You are a helpful assistant, that only communicates using JSON files and no other words.
+                The expected output from you has to be: 
+                    {
+                        "text": {response}
+                    }
+                "`
+            }
+        })
+    } else { //default to OpenAI
+        console.debug("Using default (OpenAI)")
+        return new OpenAI({
+            modelName: "gpt-3.5-turbo-16k",
+            openAIApiKey: process.env.OPENAI_API_KEY,
+        });
+    }
+}


### PR DESCRIPTION
## Summary by Sourcery

Add support for using Replicate's Llama2 model as an alternative to OpenAI's GPT model by introducing a model factory that selects the appropriate LLM based on configuration

New Features:
- Add support for Replicate's Llama2 model as an alternative language model provider with appropriate system prompts and configuration

Enhancements:
- Refactor model initialization into a dedicated factory function to support multiple LLM providers
- Improve JSON parsing safety by introducing an intermediate variable for parsed results

Chores:
- Update emoji generation prompt to specifically request unicode emojis
- Remove unused imports from various files